### PR TITLE
cmake: make project include-friendly

### DIFF
--- a/3rd_party/abseil.cmake
+++ b/3rd_party/abseil.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/fmt.cmake
+++ b/3rd_party/fmt.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/glog.cmake
+++ b/3rd_party/glog.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/protobuf.cmake
+++ b/3rd_party/protobuf.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/tests/googletest.cmake
+++ b/3rd_party/tests/googletest.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/xxhash.cmake
+++ b/3rd_party/xxhash.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,34 +13,34 @@ option(DEP_YOSYS_COMPILE_FROM_SOURCE "Compile Yosys from source instead of using
 
 ################################################################################
 
-include(deps/cmake/compile_flags.cmake)
-include(deps/cmake/coverage.cmake)
-include(deps/cmake/options.cmake)
-include(deps/cmake/sanitizers.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/compile_flags.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/coverage.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/options.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/sanitizers.cmake)
 
 ################################################################################
 
-include(3rd_party/cimg.cmake)
-include(3rd_party/abseil.cmake)
-include(3rd_party/fmt.cmake)
-include(3rd_party/glog.cmake)
-include(3rd_party/protobuf.cmake)
-include(3rd_party/xxhash.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/cimg.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/abseil.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/fmt.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/glog.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/protobuf.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/xxhash.cmake)
 
-include(deps/abc.cmake)
-include(deps/yosys.cmake)
-include(deps/protos.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/abc.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/yosys.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/protos.cmake)
 
 ################################################################################
 
 # will embed all the .v,.png,etc.
 # (ie basically make them install-ready)
-add_subdirectory(data)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/data)
 
 # the main sources
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src)
 
 if(interstellar_lib_circuits_BUILD_TESTS)
   enable_testing()
-  add_subdirectory(tests)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tests)
 endif(interstellar_lib_circuits_BUILD_TESTS)

--- a/deps/protos.cmake
+++ b/deps/protos.cmake
@@ -60,7 +60,7 @@ endfunction(compile_proto_cpp)
 
 ################################################################################
 
-compile_proto_cpp("./deps/protos/skcd/skcd.proto")
+compile_proto_cpp("${CMAKE_CURRENT_LIST_DIR}/protos/skcd/skcd.proto")
 
 ################################################################################
 


### PR DESCRIPTION
Instead of add_directory-friendly

Needed to make deps using Conan play nice with our "export_all_target_libs"
(ie when used in project api_circuits)