### PR TITLE
Yosys update

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -15,7 +15,7 @@ jobs:
       - name: install "internal" dependencies
         # TODO yosys: use proper Release build
         run: |
-          wget https://github.com/Interstellar-Network/yosys/releases/download/yosys-0.23-interstellar/yosys-0.1.1-Linux.deb -O yosys.deb
+          wget https://github.com/Interstellar-Network/yosys/releases/download/yosys-0.29/yosys-0.1.29-Linux.deb -O yosys.deb
           sudo apt-get install -y --no-install-recommends ./yosys.deb
           wget https://github.com/Interstellar-Network/abc/releases/download/0.2.0/abc-0.1.1-Linux.deb -O abc.deb
           sudo apt-get install -y --no-install-recommends ./abc.deb

--- a/3rd_party/abseil.cmake
+++ b/3rd_party/abseil.cmake
@@ -7,7 +7,7 @@ FetchContent_Declare(
   # "Abseil recommends users "live-at-head" (update to the latest commit from the master branch as often as possible)."
   # but we use LTS branch for now
   GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-  GIT_TAG 20220623.1
+  GIT_TAG 20230125.3
 )
 
 # avoids a warning:
@@ -19,3 +19,10 @@ option(ABSL_PROPAGATE_CXX_STD
   ON) # default to OFF
 
 FetchContent_MakeAvailable(abseil)
+
+target_compile_options(absl_crc32c
+  PRIVATE
+
+  # error: ignoring attributes on template argument ‘__m128i’ [-Werror=ignored-attributes]
+  -Wno-ignored-attributes
+)

--- a/3rd_party/cimg.cmake
+++ b/3rd_party/cimg.cmake
@@ -8,10 +8,10 @@ include(FetchContent)
 FetchContent_Declare(
     cimg_fetch
 
-    # "tagged this Jun 20, 2022"
+    # ~ May 2023
     # NOTE: URL instead of GIT(even with GIT_SHALLOW ON)
     # real    0m5.298s
-    URL https://github.com/GreycLab/CImg/archive/refs/tags/v.3.2.0.tar.gz
+    URL https://github.com/GreycLab/CImg/archive/refs/tags/v.3.2.5.tar.gz
 
     # time git clone https://github.com/dtschump/CImg.git --branch v.3.0.2
     # real    0m15.698s

--- a/3rd_party/fmt.cmake
+++ b/3rd_party/fmt.cmake
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 9.1.0
+    GIT_TAG 10.0.0
 )
 
 FetchContent_MakeAvailable(fmt)

--- a/3rd_party/glog.cmake
+++ b/3rd_party/glog.cmake
@@ -10,13 +10,21 @@ set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     glog
 
-    # v0.5.0 released this May 08, 2021
-    # but it does NOT compile with clang 13 and all the warnings
+    # latest release is v0.6 but it is from 2022 and does not compile with Clang 15
     GIT_REPOSITORY https://github.com/google/glog.git
-
-    GIT_TAG v0.6.0
+    GIT_TAG 3a0d4d22c5ae0b9a2216988411cfa6bf860cc372
 )
 
 FetchContent_MakeAvailable(glog)
 
 set(BUILD_TESTING "${BUILD_TESTING_SAVED}" CACHE BOOL "" FORCE)
+
+target_compile_options(glog_internal
+    PRIVATE
+
+    # glog-src/src/symbolize.cc:538:12: error: variable 'num_maps' set but not used [-Werror,-Wunused-but-set-variable]
+    # unsigned num_maps = 0;
+    $<$<CXX_COMPILER_ID:Clang>:
+    -Wno-unused-but-set-variable
+    >
+)

--- a/3rd_party/protobuf.cmake
+++ b/3rd_party/protobuf.cmake
@@ -3,9 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   protobuf_fetch
   GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
-  GIT_TAG v21.12
-
-  SOURCE_SUBDIR cmake
+  GIT_TAG v23.3
 )
 
 option(protobuf_INSTALL "Install protobuf binaries and files" OFF) # default ON
@@ -29,7 +27,10 @@ set(PROTO_CXX_FLAGS
   -Wno-unused-function
   -Wno-missing-field-initializers
   $<$<CXX_COMPILER_ID:Clang>:
-  -Wno-invalid-noreturn
+
+  # it SHOULD work b/c C++20 is officially supported; but issue ONLY with recent Clang
+  # https://github.com/protocolbuffers/protobuf/pull/12870
+  -std=c++17
   >
   $<$<CXX_COMPILER_ID:GNU>:
   -Wno-stringop-overflow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.22)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 project(lib_circuits)
 
 # ##############################################################################

--- a/data/verilog/display-main.v
+++ b/data/verilog/display-main.v
@@ -1,8 +1,15 @@
+`ifdef HAS_WATERMARK
 module main ( z , msg , watmk , rnd , pix );
+`else
+module main ( z , msg , rnd , pix );
+`endif
+
 // garbler inputs
 input z;
 input [`BITMAP_NB_SEGMENTS-1:0] msg;
+`ifdef HAS_WATERMARK
 input [`WIDTH*`HEIGHT-1:0] watmk;
+`endif
 
 // evaluator inputs
 input [`RNDSIZE-1:0] rnd;
@@ -25,5 +32,8 @@ wire [`WIDTH*`HEIGHT-1:0] pixsegments;
 xorexpand xe(.r (rnd), .p (rndx));
 rndswitch rs(.s (msg), .r (rndx), .z (z), .o (selseg));
 segment2pixel sp(.s (selseg), .p (pixsegments));
-watermark wm(.pixsegments (pixsegments), .pixwatermark (watmk), .pix (pix));
+`ifdef HAS_WATERMARK
+  watermark wm(.pixsegments (pixsegments), .pixwatermark (watmk), .pix (pix));
+`endif
+
 endmodule

--- a/src/blif/blif_parser.cpp
+++ b/src/blif/blif_parser.cpp
@@ -249,7 +249,7 @@ void BlifParser::ParseBuffer(std::string_view blif_buffer) {
   // there no way in the .blif file format to make it work with Two Party
   // Computation...
   config_.evaluator_inputs.emplace_back(
-      EvaluatorInputsType::EVALUATOR_INPUTS_RND, inputs_vect.size());
+      EvaluatorInputs{EvaluatorInputsType::EVALUATOR_INPUTS_RND, static_cast<uint32_t>(inputs_vect.size())});
   assert(config_.evaluator_inputs.size() && "BlifParser: inputs not set!");
 }
 

--- a/src/circuit_lib.cpp
+++ b/src/circuit_lib.cpp
@@ -111,16 +111,17 @@ std::string GenerateSkcd(
 
 void GenerateDisplaySkcd(
     boost::filesystem::path skcd_output_path, u_int32_t width, u_int32_t height,
-    circuits::DisplayDigitType digit_type,
+    circuits::DisplayDigitType digit_type, bool has_watermark,
     std::vector<std::tuple<float, float, float, float>> &&digits_bboxes) {
-  auto result_skcd_buf =
-      GenerateDisplaySkcd(width, height, digit_type, std::move(digits_bboxes));
+  auto result_skcd_buf = GenerateDisplaySkcd(
+      width, height, digit_type, has_watermark, std::move(digits_bboxes));
 
   utils::WriteToFile(skcd_output_path, result_skcd_buf);
 }
 
 std::string GenerateDisplaySkcd(
     u_int32_t width, u_int32_t height, DisplayDigitType digit_type,
+    bool has_watermark,
     std::vector<std::tuple<float, float, float, float>> &&digits_bboxes) {
   auto tmp_dir = utils::TempDir();
 
@@ -135,7 +136,8 @@ std::string GenerateDisplaySkcd(
   }
 
   // [1] generate Verilog segments2pixels.v
-  auto segments2pixels = Segments2Pixels(width, height, drawables);
+  auto segments2pixels =
+      Segments2Pixels(width, height, drawables, has_watermark);
   auto segments2pixels_v_str = segments2pixels.GenerateVerilog();
 
   // write this to segments2pixels.v (in the temp dir)

--- a/src/circuit_lib.h
+++ b/src/circuit_lib.h
@@ -55,7 +55,7 @@ enum class DisplayDigitType { seven_segments_png };
  */
 void GenerateDisplaySkcd(
     boost::filesystem::path skcd_output_path, u_int32_t width, u_int32_t height,
-    DisplayDigitType digit_type,
+    DisplayDigitType digit_type, bool has_watermark,
     std::vector<std::tuple<float, float, float, float>> &&digits_bboxes);
 
 /**
@@ -86,6 +86,7 @@ void GenerateDisplaySkcd(
  */
 std::string GenerateDisplaySkcd(
     u_int32_t width, u_int32_t height, DisplayDigitType digit_type,
+    bool has_watermark,
     std::vector<std::tuple<float, float, float, float>> &&digits_bboxes);
 
 }  // namespace circuits

--- a/src/segments2pixels/segments2pixels.cpp
+++ b/src/segments2pixels/segments2pixels.cpp
@@ -35,7 +35,8 @@ namespace interstellar {
 template <typename DrawableWhereT>
 Segments2Pixels<DrawableWhereT>::Segments2Pixels(
     uint32_t width, uint32_t height,
-    const std::vector<drawable::Drawable<DrawableWhereT>>& drawables)
+    const std::vector<drawable::Drawable<DrawableWhereT>>& drawables,
+    bool has_watermark)
     : drawables_(drawables) {
   // CHECK drawables MUST NOT be empty
   // We could return early instead of throwing but generating and then garbling
@@ -69,11 +70,14 @@ Segments2Pixels<DrawableWhereT>::Segments2Pixels(
   auto rndsize = static_cast<unsigned int>(
       std::max(std::ceil(0.5 * std::sqrt(8 * nb_segments + 1) + 1), 9.));
 
-  config_.garbler_inputs.emplace_back(GarblerInputs{GarblerInputsType::GARBLER_INPUTS_BUF, 1});
   config_.garbler_inputs.emplace_back(
-      GarblerInputs{GarblerInputsType::GARBLER_INPUTS_SEVEN_SEGMENTS, nb_segments});
-  config_.garbler_inputs.emplace_back(
-      GarblerInputs{GarblerInputsType::GARBLER_INPUTS_WATERMARK, width * height});
+      GarblerInputs{GarblerInputsType::GARBLER_INPUTS_BUF, 1});
+  config_.garbler_inputs.emplace_back(GarblerInputs{
+      GarblerInputsType::GARBLER_INPUTS_SEVEN_SEGMENTS, nb_segments});
+  if (has_watermark) {
+    config_.garbler_inputs.emplace_back(GarblerInputs{
+        GarblerInputsType::GARBLER_INPUTS_WATERMARK, width * height});
+  }
 
   config_.evaluator_inputs.emplace_back(
       EvaluatorInputs{EvaluatorInputsType::EVALUATOR_INPUTS_RND, rndsize});
@@ -81,6 +85,8 @@ Segments2Pixels<DrawableWhereT>::Segments2Pixels(
   config_.display_config.width = width;
   config_.display_config.height = height;
   config_.display_config.segments_type = static_cast<uint32_t>(segments_type);
+
+  has_watermark_ = has_watermark;
 }
 
 template <typename DrawableWhereT>
@@ -99,13 +105,19 @@ std::string Segments2Pixels<DrawableWhereT>::GenerateVerilog() const {
 
   std::string verilog_buf;
 
+  assert(config_.garbler_inputs[0].type ==
+             GarblerInputsType::GARBLER_INPUTS_BUF &&
+         "wrong config order in ::Segments2Pixels?");
   assert(config_.garbler_inputs[1].type ==
              GarblerInputsType::GARBLER_INPUTS_SEVEN_SEGMENTS &&
          "wrong config order in ::Segments2Pixels?");
-  assert(config_.garbler_inputs[2].type ==
-             GarblerInputsType::GARBLER_INPUTS_WATERMARK &&
-         "wrong config order in ::Segments2Pixels?");
-  assert(config_.garbler_inputs[2].length == nb_pixels && "wrong config!");
+  if (has_watermark_) {
+    assert(config_.garbler_inputs[2].type ==
+               GarblerInputsType::GARBLER_INPUTS_WATERMARK &&
+           "wrong config order in ::Segments2Pixels?");
+    assert(config_.garbler_inputs[2].length == nb_pixels && "wrong config!");
+  }
+
   unsigned int nb_inputs = config_.garbler_inputs[1].length;
 
   // without reserve : 1657472 - 1771623 (ns)
@@ -190,6 +202,9 @@ std::string Segments2Pixels<DrawableWhereT>::GetDefines() const {
                             config_.garbler_inputs[1].length);
   verilog_defines.AddDefine("WIDTH", config_.display_config.width);
   verilog_defines.AddDefine("HEIGHT", config_.display_config.height);
+  if (has_watermark_) {
+    verilog_defines.AddDefine("HAS_WATERMARK");
+  }
 
   assert(config_.evaluator_inputs[0].type ==
              EvaluatorInputsType::EVALUATOR_INPUTS_RND &&

--- a/src/segments2pixels/segments2pixels.cpp
+++ b/src/segments2pixels/segments2pixels.cpp
@@ -69,14 +69,14 @@ Segments2Pixels<DrawableWhereT>::Segments2Pixels(
   auto rndsize = static_cast<unsigned int>(
       std::max(std::ceil(0.5 * std::sqrt(8 * nb_segments + 1) + 1), 9.));
 
-  config_.garbler_inputs.emplace_back(GarblerInputsType::GARBLER_INPUTS_BUF, 1);
+  config_.garbler_inputs.emplace_back(GarblerInputs{GarblerInputsType::GARBLER_INPUTS_BUF, 1});
   config_.garbler_inputs.emplace_back(
-      GarblerInputsType::GARBLER_INPUTS_SEVEN_SEGMENTS, nb_segments);
+      GarblerInputs{GarblerInputsType::GARBLER_INPUTS_SEVEN_SEGMENTS, nb_segments});
   config_.garbler_inputs.emplace_back(
-      GarblerInputsType::GARBLER_INPUTS_WATERMARK, width * height);
+      GarblerInputs{GarblerInputsType::GARBLER_INPUTS_WATERMARK, width * height});
 
   config_.evaluator_inputs.emplace_back(
-      EvaluatorInputsType::EVALUATOR_INPUTS_RND, rndsize);
+      EvaluatorInputs{EvaluatorInputsType::EVALUATOR_INPUTS_RND, rndsize});
 
   config_.display_config.width = width;
   config_.display_config.height = height;

--- a/src/segments2pixels/segments2pixels.h
+++ b/src/segments2pixels/segments2pixels.h
@@ -45,11 +45,15 @@ class Segments2Pixels {
    * here all the way to the Packmsg.
    * To generate the correct OTP/permutation in the Packmsg we MUST make sure
    * what we draw here matches the Packmsg.
+   *
+   * has_watermark: matches ifdef "HAS_WATERMARK" in
+   * lib_circuits_wrapper/deps/lib_circuits/data/verilog/display-main.v
    */
   // TODO Span for "drawables"
   Segments2Pixels(
       uint32_t width, uint32_t height,
-      const std::vector<drawable::Drawable<DrawableWhereT>>& drawables);
+      const std::vector<drawable::Drawable<DrawableWhereT>>& drawables,
+      bool has_watermark);
 
   // Disable copy semantics.
   Segments2Pixels(const Segments2Pixels&) = delete;
@@ -68,6 +72,7 @@ class Segments2Pixels {
  private:
   const std::vector<drawable::Drawable<DrawableWhereT>>& drawables_;
   SkcdConfig config_;
+  bool has_watermark_;
 };
 
 }  // namespace interstellar

--- a/src/skcd/skcd.cpp
+++ b/src/skcd/skcd.cpp
@@ -15,6 +15,7 @@
 #include "skcd.h"
 
 #include <glog/logging.h>
+#include <fstream>
 
 #include "blif/gate_types.h"
 #include "skcd.pb.h"

--- a/src/utils/encode_rle/rle.h
+++ b/src/utils/encode_rle/rle.h
@@ -15,16 +15,17 @@
 #pragma once
 
 #include <vector>
+#include <cstdint>
 
 namespace interstellar {
 
 namespace utils {
 
 struct RLE_int8_t {
-  u_int32_t size;
+  uint32_t size;
   int8_t value;
 
-  RLE_int8_t(u_int32_t size, int8_t value);
+  RLE_int8_t(uint32_t size, int8_t value);
 };
 
 }  // namespace utils

--- a/src/utils/files/utils_files.cpp
+++ b/src/utils/files/utils_files.cpp
@@ -17,6 +17,7 @@
 #include <absl/random/random.h>
 #include <absl/strings/str_cat.h>
 #include <glog/logging.h>
+#include <fstream>
 
 // the final tmp dir is "/tmp/${kTmpSubDir}/${random_string}/"
 static constexpr char kTmpSubDir[] = "interstellar-circuits";

--- a/src/verilog/verilog_compiler.cpp
+++ b/src/verilog/verilog_compiler.cpp
@@ -174,8 +174,7 @@ void CompileVerilog(const std::vector<std::string_view> &inputs_v_full_paths,
   Yosys::Pass::call(&yosys_design, "fsm");
 	Yosys::Pass::call(&yosys_design, "opt");
   Yosys::Pass::call(&yosys_design, "wreduce");
-  // TODO fix: "ERROR: No such command: peepopt"
-  // Yosys::Pass::call(&yosys_design, "peepopt");
+  Yosys::Pass::call(&yosys_design, "peepopt");
   Yosys::Pass::call(&yosys_design, "opt_clean");
   // Yosys::Pass::call(&yosys_design, "techmap -map +/cmp2lut.v -map +/cmp2lcu.v");
   Yosys::Pass::call(&yosys_design, "alumacc");

--- a/src/verilog/verilog_compiler.cpp
+++ b/src/verilog/verilog_compiler.cpp
@@ -160,19 +160,24 @@ void CompileVerilog(const std::vector<std::string_view> &inputs_v_full_paths,
       &yosys_design,
       absl::StrCat("read_verilog ", absl::StrJoin(inputs_v_full_paths, " ")));
 
-  // TODO?
-  // https://stackoverflow.com/questions/31434380/what-is-a-good-template-yosys-synthesis-script
+  	// TODO?
+	// https://stackoverflow.com/questions/31434380/what-is-a-good-template-yosys-synthesis-script
+  // Yosys::Pass::call(&yosys_design, "synth"); -> this is sort of the commands below:
   Yosys::Pass::call(&yosys_design, "hierarchy -check");
-  // TODO!!! update for new Yosys version?
-  // Yosys::Pass::call(&yosys_design, "proc");
-  // Yosys::Pass::call(&yosys_design, "opt");
-  // Yosys::Pass::call(&yosys_design, "memory");
-  // Yosys::Pass::call(&yosys_design, "opt -fast");
-  // Yosys::Pass::call(&yosys_design, "synth");
-  // Yosys::Pass::call(&yosys_design, "opt");
-  Yosys::Pass::call(&yosys_design, "techmap");
-  Yosys::Pass::call(&yosys_design, "opt");
-  // TODO Yosys::Pass::call(&yosys_design, "check -assert");
+	Yosys::Pass::call(&yosys_design, "proc");
+  Yosys::Pass::call(&yosys_design, "flatten");
+  Yosys::Pass::call(&yosys_design, "opt_expr");
+  Yosys::Pass::call(&yosys_design, "opt_clean");
+  Yosys::Pass::call(&yosys_design, "check");
+  Yosys::Pass::call(&yosys_design, "opt -nodffe -nosdff");
+  Yosys::Pass::call(&yosys_design, "fsm");
+	Yosys::Pass::call(&yosys_design, "opt -fast");
+  Yosys::Pass::call(&yosys_design, "memory");
+  Yosys::Pass::call(&yosys_design, "opt -fast");
+	Yosys::Pass::call(&yosys_design, "techmap");
+	Yosys::Pass::call(&yosys_design, "opt -fast");
+	Yosys::Pass::call(&yosys_design, "clean");
+  Yosys::Pass::call(&yosys_design, "check -assert");
 
   // Yosys::Pass::call(&yosys_design, "synth -noabc");
   // Yosys::Pass::call(&yosys_design, "abc");

--- a/src/verilog/verilog_compiler.cpp
+++ b/src/verilog/verilog_compiler.cpp
@@ -163,6 +163,7 @@ void CompileVerilog(const std::vector<std::string_view> &inputs_v_full_paths,
   	// TODO?
 	// https://stackoverflow.com/questions/31434380/what-is-a-good-template-yosys-synthesis-script
   // Yosys::Pass::call(&yosys_design, "synth"); -> this is sort of the commands below:
+  // CHECK: the default with "./yosys_exe" > "help synth"
   Yosys::Pass::call(&yosys_design, "hierarchy -check");
 	Yosys::Pass::call(&yosys_design, "proc");
   Yosys::Pass::call(&yosys_design, "flatten");
@@ -171,13 +172,31 @@ void CompileVerilog(const std::vector<std::string_view> &inputs_v_full_paths,
   Yosys::Pass::call(&yosys_design, "check");
   Yosys::Pass::call(&yosys_design, "opt -nodffe -nosdff");
   Yosys::Pass::call(&yosys_design, "fsm");
-	Yosys::Pass::call(&yosys_design, "opt -fast");
-  Yosys::Pass::call(&yosys_design, "memory");
+	Yosys::Pass::call(&yosys_design, "opt");
+  Yosys::Pass::call(&yosys_design, "wreduce");
+  // TODO fix: "ERROR: No such command: peepopt"
+  // Yosys::Pass::call(&yosys_design, "peepopt");
+  Yosys::Pass::call(&yosys_design, "opt_clean");
+  // Yosys::Pass::call(&yosys_design, "techmap -map +/cmp2lut.v -map +/cmp2lcu.v");
+  Yosys::Pass::call(&yosys_design, "alumacc");
+  Yosys::Pass::call(&yosys_design, "share");
+  Yosys::Pass::call(&yosys_design, "opt");
+  Yosys::Pass::call(&yosys_design, "memory -nomap");
+  Yosys::Pass::call(&yosys_design, "opt_clean");
+
+  Yosys::Pass::call(&yosys_design, "opt -fast -full");
+  Yosys::Pass::call(&yosys_design, "memory_map");
+  Yosys::Pass::call(&yosys_design, "opt -full");
+  Yosys::Pass::call(&yosys_design, "techmap");
+  // Yosys::Pass::call(&yosys_design, "techmap -map +/gate2lut.v");
+  // Yosys::Pass::call(&yosys_design, "clean; opt_lut");
+  // Yosys::Pass::call(&yosys_design, "flowmap -maxlut K");
   Yosys::Pass::call(&yosys_design, "opt -fast");
-	Yosys::Pass::call(&yosys_design, "techmap");
-	Yosys::Pass::call(&yosys_design, "opt -fast");
-	Yosys::Pass::call(&yosys_design, "clean");
-  Yosys::Pass::call(&yosys_design, "check -assert");
+
+  // TODO? with or without: -assert?
+  Yosys::Pass::call(&yosys_design, "hierarchy -check");
+  Yosys::Pass::call(&yosys_design, "stat");
+  Yosys::Pass::call(&yosys_design, "check");
 
   // Yosys::Pass::call(&yosys_design, "synth -noabc");
   // Yosys::Pass::call(&yosys_design, "abc");

--- a/src/verilog_defines/verilog_defines.cpp
+++ b/src/verilog_defines/verilog_defines.cpp
@@ -32,14 +32,27 @@ void Defines::AddDefine(std::string_view key, std::string_view value) {
     throw std::runtime_error("key MUST NOT start with a backtick(`)!");
   }
 
-  defines_map_.try_emplace(key, value);
+  defines_map_.try_emplace(key, std::make_optional(value));
   assert(defines_map_.at(key) == value && "new value was not updated!");
+}
+
+void Defines::AddDefine(std::string_view key) {
+  if (absl::StartsWith(key, "`")) {
+    throw std::runtime_error("key MUST NOT start with a backtick(`)!");
+  }
+
+  defines_map_.try_emplace(key, std::nullopt);
+  assert(defines_map_.at(key) == std::nullopt && "new value was not updated!");
 }
 
 std::string Defines::GetDefinesVerilog() {
   std::string defines_buf;
   for (auto const& [key, val] : defines_map_) {
-    absl::StrAppend(&defines_buf, "`define ", key, " ", val, "\n");
+    if (val) {
+      absl::StrAppend(&defines_buf, "`define ", key, " ", *val, "\n");
+    } else {
+      absl::StrAppend(&defines_buf, "`define ", key, "\n");
+    }
   }
 
   return defines_buf;

--- a/src/verilog_defines/verilog_defines.h
+++ b/src/verilog_defines/verilog_defines.h
@@ -16,7 +16,9 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <initializer_list>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace interstellar {
 
@@ -38,6 +40,8 @@ class Defines {
 
   void AddDefine(std::string_view key, uint32_t value);
 
+  void AddDefine(std::string_view key);
+
   /**
    * Return the defines properly formatted as Verilog
    * eg:
@@ -49,7 +53,7 @@ class Defines {
   std::string GetDefinesVerilog();
 
  private:
-  absl::flat_hash_map<std::string, std::string> defines_map_;
+  absl::flat_hash_map<std::string, std::optional<std::string>> defines_map_;
 };
 
 }  // namespace verilog

--- a/tests/cli_display_skcd.cpp
+++ b/tests/cli_display_skcd.cpp
@@ -26,6 +26,8 @@ ABSL_FLAG(u_int32_t, width, 1280 / 2, "width");
 ABSL_FLAG(u_int32_t, height, 720 / 2, "height");
 ABSL_FLAG(u_int32_t, nb_digits, 2, "nb_digits");
 ABSL_FLAG(bool, is_message, true, "is_message");
+ABSL_FLAG(bool, has_watermark, true,
+          "has_watermark: cf HAS_WATERMARK in data/verilog/");
 
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
@@ -36,6 +38,7 @@ int main(int argc, char** argv) {
   auto height = absl::GetFlag(FLAGS_height);
   auto nb_digits = absl::GetFlag(FLAGS_nb_digits);
   auto is_message = absl::GetFlag(FLAGS_is_message);
+  auto has_watermark = absl::GetFlag(FLAGS_has_watermark);
 
   std::vector<std::tuple<float, float, float, float>> digits_bboxes;
 
@@ -57,7 +60,7 @@ int main(int argc, char** argv) {
 
   circuits::GenerateDisplaySkcd(output_skcd_path, width, height,
                                 circuits::DisplayDigitType::seven_segments_png,
-                                std::move(digits_bboxes));
+                                has_watermark, std::move(digits_bboxes));
 
   return 0;
 }

--- a/tests/full_pipeline_test.cpp
+++ b/tests/full_pipeline_test.cpp
@@ -99,7 +99,7 @@ TEST(FullPipelineTest, BasicDisplayFileOk) {
 
   circuits::GenerateDisplaySkcd(output_skcd_path, 120, 52,
                                 circuits::DisplayDigitType::seven_segments_png,
-                                std::move(digits_bboxes));
+                                true, std::move(digits_bboxes));
 
   // TODO ideally we would want to compare functionally
   // ie are those the same gates? inputs? outputs? etc

--- a/tests/segments2pixels_test.cpp
+++ b/tests/segments2pixels_test.cpp
@@ -45,7 +45,8 @@ TEST(Segments2PixelsTest, BasicDisplayOk) {
       seven_segs_png);
 
   // ~ minimal size that still displays all the segments in lib_garble's eval
-  auto segments2pixels = interstellar::Segments2Pixels(120, 52, drawables);
+  auto segments2pixels =
+      interstellar::Segments2Pixels(120, 52, drawables, true);
 
   auto expected_str = interstellar::utils::ReadFile(
       absl::StrCat(interstellar::test::test_data_dir,
@@ -55,10 +56,13 @@ TEST(Segments2PixelsTest, BasicDisplayOk) {
   // compare
   auto res_defines_lines =
       absl::StrSplit(segments2pixels.GetDefines(), "\n", absl::SkipEmpty());
-  ASSERT_THAT(res_defines_lines,
-              testing::UnorderedElementsAreArray(
-                  {"`define WIDTH 120", "`define BITMAP_NB_SEGMENTS 14",
-                   "`define RNDSIZE 9", "`define HEIGHT 52"}));
+  ASSERT_THAT(res_defines_lines, testing::UnorderedElementsAreArray({
+                                     "`define WIDTH 120",
+                                     "`define BITMAP_NB_SEGMENTS 14",
+                                     "`define RNDSIZE 9",
+                                     "`define HEIGHT 52",
+                                     "`define HAS_WATERMARK",
+                                 }));
 
   EXPECT_EQ(segments2pixels.GenerateVerilog(), expected_str);
 }


### PR DESCRIPTION
- verilog_compiler: use the full commands, same a Yosys `synth`
- yosys: update to [0.29](https://github.com/Interstellar-Network/yosys/releases/tag/yosys-0.29), branched off https://github.com/YosysHQ/yosys/releases/tag/yosys-0.29
- bump all deps: abseil, CImg, glog, fmt
- fix small compiler errors/warnings with latest Clang (15) and GCC (13)